### PR TITLE
Bugfix/shaply dependency fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@ FROM jupyter/all-spark-notebook
 
 USER root
 
+RUN sudo apt-get update 
+RUN sudo apt-get install -y libgeos-dev
 RUN pip install Shapely==1.6.4.post2
 RUN pip install pyspark==2.3.1
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ USER root
 RUN sudo apt-get update 
 RUN sudo apt-get install -y libgeos-dev
 RUN pip install Shapely==1.6.4.post2
-RUN pip install pyspark==2.3.1
+RUN pip install pyspark==2.3.1 toree==0.4.0
 
 # Ensure we overwrite the kernel config so that toree connects to cluster
 RUN jupyter toree install --sys-prefix --spark_opts="--master yarn --deploy-mode client --driver-memory 2g  --executor-memory 6g  --executor-cores 4 --driver-java-options -Dhdp.version=2.5.3.0-37 --conf spark.hadoop.yarn.timeline-service.enabled=false"


### PR DESCRIPTION
This PR fix two issues: 

1. https://github.com/eliiza/challenge-urban-forest/issues/1 by installing shapely dependencies
2. After fix the above issue, the docker image build process progress and throw the following error:

```bash
Step 7/10 : RUN jupyter toree install --sys-prefix --spark_opts="--master yarn --deploy-mode client --driver-memory 2g  --executor-memory 6g  --executor-cores 4 --driver-java-options -Dhdp.version=2.5.3.0-37 --conf spark.hadoop.yarn.timeline-service.enabled=false"
 ---> Running in 1577561fbb95
Traceback (most recent call last):
  File "/opt/conda/bin/jupyter", line 11, in <module>
    sys.exit(main())
  File "/opt/conda/lib/python3.8/site-packages/jupyter_core/command.py", line 247, in main
    command = _jupyter_abspath(subcommand)
  File "/opt/conda/lib/python3.8/site-packages/jupyter_core/command.py", line 133, in _jupyter_abspath
    raise Exception(
Exception: Jupyter command `jupyter-toree` not found.
```
Seem like toree is no longer installed in the upsream image.

After adding the installation, I was able to build the image and run as per readme.